### PR TITLE
Updated selectors to work not only with the English recaptcha interface

### DIFF
--- a/selenium_recaptcha_solver/solver.py
+++ b/selenium_recaptcha_solver/solver.py
@@ -77,8 +77,8 @@ class RecaptchaSolver:
         self._driver.switch_to.parent_frame()
 
         captcha_challenge = self._wait_for_element(
-            by=By.XPATH,
-            locator='//iframe[@title="recaptcha challenge expires in two minutes"]',
+            by=By.CSS_SELECTOR,
+            locator='.g-recaptcha-bubble-arrow + div > iframe',
             timeout=5,
         )
 

--- a/selenium_recaptcha_solver/solver.py
+++ b/selenium_recaptcha_solver/solver.py
@@ -78,7 +78,7 @@ class RecaptchaSolver:
 
         captcha_challenge = self._wait_for_element(
             by=By.CSS_SELECTOR,
-            locator='.g-recaptcha-bubble-arrow + div > iframe',
+            locator='iframe[src*="www.google.com/recaptcha/api2/bframe"]',
             timeout=5,
         )
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -32,7 +32,7 @@ def test_solver():
 
         test_driver.execute_script("document.getElementById('recaptcha-demo-submit').click()")
 
-        test_driver.find_element(By.XPATH, '//*[text()="Verification Success... Hooray!"]')
+        test_driver.find_element(By.CSS_SELECTOR, '.recaptcha-success')
 
     except Exception:
         pytest.fail('Failed to automatically resolve ReCAPTCHA.')


### PR DESCRIPTION
If the reCAPTCHA interface is not shown in English, the `title` of the iframe is not "recaptcha request expires in two minutes" and it causes a failure