### PR TITLE
Add try-except block to click on reCAPTCHA image button.

### DIFF
--- a/selenium_recaptcha_solver/solver.py
+++ b/selenium_recaptcha_solver/solver.py
@@ -94,6 +94,16 @@ class RecaptchaSolver:
 
         self._driver.switch_to.frame(iframe)
 
+        # If the captcha image audio is available, locate it. Otherwise, skip to the next line of code.
+        try:
+            self._wait_for_element(
+                by=By.XPATH,
+                locator='//*[@id="recaptcha-image-button"]',
+                timeout=10,
+            ).click()
+        except TimeoutException:
+            pass
+
         # Locate captcha audio button and click it via JavaScript
         audio_button = self._wait_for_element(
             by=By.ID,


### PR DESCRIPTION
This commit adds a try-except block to the solver.py, The try block attempts to locate and click on the reCAPTCHA image button. If the button is not found within the timeout period (10 seconds), the except block catches the TimeoutException and continues without raising an error. Additionally, this try-except block checks if the reCAPTCHA challenge type is set to audio, which can occur when visiting the same website multiple times. By checking the challenge type, this change improves the stability and robustness of the reCAPTCHA solving process. This is especially relevant for users who frequently visit the same website and are likely to encounter this issue. Overall, this commit improves the reliability of the module.

While this may seem like a small change, it can make a significant difference in the reliability of the reCAPTCHA solving module. Thank you for your consideration!