### PR TITLE
Update solver.py

### DIFF
--- a/selenium_recaptcha_solver/solver.py
+++ b/selenium_recaptcha_solver/solver.py
@@ -96,24 +96,12 @@ class RecaptchaSolver:
         try:
             self._wait_for_element(
                 by=By.XPATH,
-                locator='//*[@id="recaptcha-image-button"]',
+                locator='//*[@id="recaptcha-audio-button"]',
                 timeout=1,
             ).click()
 
         except TimeoutException:
             pass
-
-        # Locate captcha audio button and click it via JavaScript
-        audio_button = self._wait_for_element(
-            by=By.ID,
-            locator='recaptcha-audio-button',
-            timeout=10,
-        )
-
-        self._js_click(audio_button)
-
-        if self._delay_config:
-            self._delay_config.delay_after_click_audio_button()
 
         self._solve_audio_challenge()
 


### PR DESCRIPTION
Only trying to click "recaptcha-audio-button", after which directly go to "_solve_audio_challenge". 

Reasons:
The current way of trying to click "recaptcha-image-button" first can easily trigger the"Google automated queries detetion" if the audio challenge is shown in the first place instead of an image challenge.

The proposed changes can simplify the process, as either successfully or unsuccessfully clicking "recaptcha-audio-button", the audio challenge is ready to be solved.